### PR TITLE
AVX-129: Hard code camera settings to be like IR-Lock's firmware

### DIFF
--- a/src/device/common/inc/cameravals.h
+++ b/src/device/common/inc/cameravals.h
@@ -23,9 +23,11 @@
 #define CAM_LIGHT_LOW           1
 #define CAM_LIGHT_HIGH          2 // not sure if combining high light and low light exposure is possible, or good
 
-#define CAM_BRIGHTNESS_DEFAULT  80
+#define CAM_BRIGHTNESS_DEFAULT  90
 #define CAM_BRIGHTNESS_RANGE    0x14
 
+#define CAM_WBV_DEFAULT         8421504
+#define CAM_ECV_DEFAULT         8600
 
 #define CAM_RES0                0x00 
 #define CAM_RES1                0x01

--- a/src/device/libpixy_m4/src/camera.cpp
+++ b/src/device/libpixy_m4/src/camera.cpp
@@ -601,22 +601,22 @@ void cam_loadParams()
 	prm_setShadowCallback("Camera Brightness", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("Auto Exposure Correction", PRM_FLAG_ADVANCED | PRM_FLAG_CHECKBOX, 
-		"@c Camera Enables/disables Auto Exposure Correction. (default enabled)", UINT8(1), END);
+		"@c Camera Enables/disables Auto Exposure Correction. (default disabled)", UINT8(0), END);
 	prm_setShadowCallback("Auto Exposure Correction", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("AEC Value", PRM_FLAG_INTERNAL, 
-		"", UINT32(0), END);
+		"", UINT32(CAM_ECV_DEFAULT), END);
 																		   
 	prm_add("Auto White Balance", PRM_FLAG_ADVANCED | PRM_FLAG_CHECKBOX, 
 		"@c Camera Enables/disables Auto White Balance. When this is set, AWB is enabled continuously. (default disabled)", UINT8(0), END);
 	prm_setShadowCallback("Auto White Balance", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("Auto White Balance on power-up", PRM_FLAG_ADVANCED | PRM_FLAG_CHECKBOX, 
-		"@c Camera Enables/disables Auto White Balance on power-up. When this is set, AWB is enabled only upon power-up. (default enabled)", UINT8(1), END);
+		"@c Camera Enables/disables Auto White Balance on power-up. When this is set, AWB is enabled only upon power-up. (default disabled)", UINT8(0), END);
 	prm_setShadowCallback("Auto White Balance on power-up", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("AWB Value", PRM_FLAG_INTERNAL,
-		"", UINT32(0), END);
+		"", UINT32(CAM_WBV_DEFAULT), END);
 
 	uint8_t brightness, aec, awb, awbp;
 	uint32_t ecv, wbv;

--- a/src/device/main_m4/inc/exec.h
+++ b/src/device/main_m4/inc/exec.h
@@ -23,7 +23,7 @@
 
 #define FW_MAJOR_VER		2
 #define FW_MINOR_VER		0
-#define FW_BUILD_VER		19
+#define FW_BUILD_VER		20
 #ifdef LEGO
 #define FW_TYPE             "LEGO"
 #else


### PR DESCRIPTION
Change camera settings to match IR-Lock's firmware