### PR TITLE
AVX-127: Add python script to capture frames from pixy via USB

### DIFF
--- a/scripts/build_libpixyusb_swig.sh
+++ b/scripts/build_libpixyusb_swig.sh
@@ -27,13 +27,13 @@ then
   OS="__LINUX__"
 fi
 
-cp get_blocks.py $PIXY_ROOT/build/$TARGET_BUILD_FOLDER
 cp pixy.i $PIXY_ROOT/build/$TARGET_BUILD_FOLDER
-cp setup.py $PIXY_ROOT/build/$TARGET_BUILD_FOLDER
+cp *.py $PIXY_ROOT/build/$TARGET_BUILD_FOLDER
+cp *.h $PIXY_ROOT/build/$TARGET_BUILD_FOLDER
 
 cd $PIXY_ROOT/build/$TARGET_BUILD_FOLDER
 
-swig -c++ -python pixy.i 
+swig -c++ -python pixy.i
 
 if [ "$1" == "debug" ]
 then

--- a/src/host/libpixyusb_swig/get_blocks.py
+++ b/src/host/libpixyusb_swig/get_blocks.py
@@ -27,7 +27,7 @@ while 1:
 
   if count > 0:
     # Blocks found #
-    print 'frame %3d:' % (frame)
+    print ('frame %3d:' % (frame))
     frame = frame + 1
     for index in range (0, count):
-      print '[BLOCK_TYPE=%d SIG=%d X=%3d Y=%3d WIDTH=%3d HEIGHT=%3d]' % (blocks[index].type, blocks[index].signature, blocks[index].x, blocks[index].y, blocks[index].width, blocks[index].height)
+      print ('[BLOCK_TYPE=%d SIG=%d X=%3d Y=%3d WIDTH=%3d HEIGHT=%3d]' % (blocks[index].type, blocks[index].signature, blocks[index].x, blocks[index].y, blocks[index].width, blocks[index].height))

--- a/src/host/libpixyusb_swig/get_frame.py
+++ b/src/host/libpixyusb_swig/get_frame.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+
+##
+# @file get_frame.py
+# @brief This script captures frames from the Pixy over USB. The output image is 640x400 resolution.
+#        The pixy can only store 320x200 pixels due to the limited RAM. To get 640x400, four 320x200 images
+#        are captured and stitched together. You can see the stitching effect if you move the camera.
+#        This is only used for capturing still images to analyze the image quality of the IR light.
+#        The images are saved automatically to grayscale bmp image format. Bmp is used because it is lossless
+#        and it's easy to parse for analysis.
+#
+#        Note the image is not demosaiced. Each pixel follows the bayer pattern BG/GR.
+#
+# @copyright Copyright 2021 Matternet. All rights reserved.
+#
+
+import cv2
+from datetime import datetime
+import numpy as np
+import os
+import pixy
+import time
+
+
+VERSION = "v1.0.0"
+IMAGES_DIR = "images"
+
+# Pixy can only hold this much of pixels in its memory.
+# To get a bigger picture, the image is stitched together with subsequent frames.
+SUB_WIDTH = 320
+SUB_HEIGHT = 200
+
+# This is the resolution we want to work with
+FRAME_WIDTH = 640
+FRAME_HEIGHT = 400
+
+# The bitmap images files are not compressed.
+# Limit the number of images saved so it doesn't use up all storage space
+# if user left it running forever!
+IMAGE_SIZE = FRAME_WIDTH * FRAME_HEIGHT
+MAX_SAVED_IMAGES_SIZE = 1 * 1000 * 1000 * 1000  # 1GB
+MAX_SAVED_IMAGES_COUNT = int(MAX_SAVED_IMAGES_SIZE / IMAGE_SIZE)
+
+
+## Get a subframe (320x200) of the 640x400 image
+# @param data Buffer for receiving subframe from pixy
+# @param frame Full frame image buffer
+# @param xoffset X offset
+# @param yoffset Y offset
+def get_subframe(data, frame, xoffset, yoffset):
+    # Get frame from camera. Mode 0x11 is to tell pixy to capture frame at 640x400.
+    # However, pixy can only store 320x200 in RAM. Caller must make multiple calls to this function.
+    pixy.pixy_cam_get_frame(0x11, xoffset, yoffset, SUB_WIDTH, SUB_HEIGHT, data)
+
+    # Convert to numpy matrix
+    for h in xrange(SUB_HEIGHT):
+        for w in xrange(SUB_WIDTH):
+            frame[yoffset + h, xoffset + w] = data[h * SUB_WIDTH + w]
+
+
+## Main function to capture images from pixy camera
+def main():
+    print("Pixy Python " + VERSION)
+
+    # Create directory to save images
+    if not os.path.exists(IMAGES_DIR):
+        os.mkdir(IMAGES_DIR)
+
+    # Create a directory for this session
+    image_dir = IMAGES_DIR + "/" + str(datetime.now().strftime("%Y%m%d_%H%M%S"))
+    os.mkdir(image_dir)
+    print("Saving images to " + image_dir)
+    print("Press Q to quit.")
+
+    pixy.pixy_init()            # Initialize Pixy interface
+    pixy.pixy_command("stop")   # Stop default program
+
+    # Allocate memory to store image from camera
+    data = pixy.byteArray(SUB_WIDTH * SUB_HEIGHT)
+
+    # Allocate numpy matrix to display
+    frame = np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 1), dtype=np.uint8)
+    frame_cnt = 0
+
+    while True:
+        get_subframe(data, frame,   0,   0)
+        get_subframe(data, frame, 320,   0)
+        get_subframe(data, frame,   0, 200)
+        get_subframe(data, frame, 320, 200)
+
+        # Show image
+        cv2.imshow('pixy', frame)
+
+        # Save image to file. Use bitmap format because it's lossless and easy to read back/analyze.
+        if frame_cnt < MAX_SAVED_IMAGES_COUNT:
+            cv2.imwrite(image_dir + '/{:06d}.bmp'.format(frame_cnt), frame)
+        frame_cnt = frame_cnt + 1
+
+        # Check user request to exit
+        if cv2.waitKey(1) == ord('q'):
+            break
+
+        # Sleep 20ms. Camera can only sample at 50fps max.
+        time.sleep(.02)
+
+    cv2.destroyAllWindows()
+    pixy.pixy_close()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/host/libpixyusb_swig/helper_commands.cpp
+++ b/src/host/libpixyusb_swig/helper_commands.cpp
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+#include "pixy.h"
+
+
+// frame should be at least 64000 bytes
+int pixy_cam_get_frame(uint8_t mode, uint16_t xoffset, uint16_t yoffset, uint16_t width, uint16_t height, uint8_t *frame)
+{
+    if (frame == NULL)
+    {
+        return -1;
+    }
+
+    uint8_t *out_pixels;
+    int32_t out_fourcc;
+    int8_t out_flags;
+    uint16_t out_width;
+    uint16_t out_height;
+    uint32_t out_pixel_cnt;
+    int32_t out_response = 0;
+    int ret;
+
+    ret = pixy_command("cam_getFrame",
+                        CRP_UINT8,  mode,
+                        CRP_UINT16, xoffset,
+                        CRP_UINT16, yoffset,
+                        CRP_UINT16, width,
+                        CRP_UINT16, height,
+                        END_OUT_ARGS,        // separator
+                        &out_response,       // pointer to mem address for return value
+                        &out_fourcc,         // contrary to docs, the next 5 args are needed
+                        &out_flags,
+                        &out_width,
+                        &out_height,
+                        &out_pixel_cnt,
+                        &out_pixels,         // pointer to mem address for returned frame
+                        END_IN_ARGS);
+
+    if (ret == 0)
+    {
+        memcpy(frame, out_pixels, out_pixel_cnt);
+    }
+
+    return ret;
+}

--- a/src/host/libpixyusb_swig/helper_commands.h
+++ b/src/host/libpixyusb_swig/helper_commands.h
@@ -1,0 +1,7 @@
+#ifndef HELPER_COMMANDS
+#define HELPER_COMMANDS
+
+// frame should be at least 64000 bytes
+int pixy_cam_get_frame(uint8_t mode, uint16_t xoffset, uint16_t yoffset, uint16_t width, uint16_t height, uint8_t *frame);
+
+#endif

--- a/src/host/libpixyusb_swig/pixy.i
+++ b/src/host/libpixyusb_swig/pixy.i
@@ -2,16 +2,43 @@
 
 %include "stdint.i"
 %include "carrays.i"
+%include "cdata.i"
+%include "typemaps.i"
 
 %{
 #define SWIG_FILE_WITH_INIT
 #include "pixy.h"
+#include "helper_commands.h"
 %}
 
 %array_class(struct Block, BlockArray);
 
+// Expose a function to create a uint8_t array in Python
+%array_class(unsigned char, byteArray);
+%include "helper_commands.h"
+
+// Define these as output arguments
+int pixy_cam_get_exposure_compensation(uint8_t *OUTPUT, uint16_t *OUTPUT);
+int pixy_get_firmware_version(uint16_t *OUTPUT, uint16_t *OUTPUT, uint16_t *OUTPUT);
+
+
 int pixy_init();
+int pixy_command(const char *name, ...);
 int pixy_get_blocks(uint16_t max_blocks, BlockArray *blocks);
+int pixy_led_set_RGB(uint8_t red, uint8_t green, uint8_t blue);
+int pixy_led_set_max_current(uint32_t current);
+int pixy_led_get_max_current();
+int pixy_cam_set_auto_white_balance(uint8_t value);
+int pixy_cam_get_auto_white_balance();
+uint32_t pixy_cam_get_white_balance_value();
+int pixy_cam_set_white_balance_value(uint8_t red, uint8_t green, uint8_t blue);
+int pixy_cam_set_auto_exposure_compensation(uint8_t enable);
+int pixy_cam_get_auto_exposure_compensation();
+int pixy_cam_set_exposure_compensation(uint8_t gain, uint16_t compensation);
+int pixy_cam_get_exposure_compensation(uint8_t *gain, uint16_t *compensation);
+int pixy_cam_set_brightness(uint8_t brightness);
+int pixy_cam_get_brightness();
+int pixy_get_firmware_version(uint16_t *major, uint16_t *minor, uint16_t *build);
 void pixy_close();
 
 struct Block

--- a/src/host/libpixyusb_swig/set_exposure.py
+++ b/src/host/libpixyusb_swig/set_exposure.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+
+##
+# @file set_exposure.py
+# @brief This script sets the gain and exposure settings of the camera.
+#
+# @copyright Copyright 2021 Matternet. All rights reserved.
+#
+
+import os
+import pixy
+import sys
+
+
+## Prints the current gain and exposure compensation settings.
+def print_exposure():
+    retval, gain, exp = pixy.pixy_cam_get_exposure_compensation()
+    print("Gain: 0x{:02x}, Exposure 0x{:04x}".format(gain, exp))
+
+
+## Main function to set gain and exposure compensation settings.
+#  @param ecv Scalar value that includes gain and compensation to match PixyMon.
+def main(ecv):
+    pixy.pixy_init()
+    pixy.pixy_command("stop")
+
+    # Get current exposure values
+    print("Current exposure setting:")
+    print_exposure()
+
+    # Set exposure value
+    gain = ecv & 0xFF
+    comp = (ecv >> 8) & 0xFFFF
+    pixy.pixy_cam_set_exposure_compensation(gain, comp)
+
+    # Confirm exposure value
+    print("")
+    print("Exposure set to:")
+    print_exposure()
+
+    # Close connection
+    pixy.pixy_close()
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print("Usage: " + sys.argv[0] + " <ECV_Hex>     # e.g. 0xA598")
+    else:
+        ecv = int(sys.argv[1], 16)
+        main(ecv)

--- a/src/host/libpixyusb_swig/setup.py
+++ b/src/host/libpixyusb_swig/setup.py
@@ -4,24 +4,26 @@ from distutils.core import setup, Extension
 
 # The paths used in this file are relative to: PIXY_ROOT/build #
 
-pixy_module = Extension('_pixy', 
+pixy_module = Extension('_pixy',
 	include_dirs = ['/usr/include/libusb-1.0',
-  '/usr/local/include/libusb-1.0',
+	'/usr/local/include/libusb-1.0',
 	'../../src/common/inc',
 	'../../src/host/libpixyusb/src/utils',
-  '../../src/host/libpixyusb/include'],
+	'../../src/host/libpixyusb/include',
+	'../../src/host/libpixyusb_swig'],
 	libraries = ['boost_thread',
 	'boost_system',
 	'boost_chrono',
 	'pthread',
 	'usb-1.0'],
-	sources=['pixy_wrap.cxx', 
+	sources=['pixy_wrap.cxx',
 	'../../src/common/src/chirp.cpp',
 	'../../src/host/libpixyusb/src/pixy.cpp',
 	'../../src/host/libpixyusb/src/chirpreceiver.cpp',
 	'../../src/host/libpixyusb/src/pixyinterpreter.cpp',
 	'../../src/host/libpixyusb/src/usblink.cpp',
-	'../../src/host/libpixyusb/src/utils/timer.cpp'])
+	'../../src/host/libpixyusb/src/utils/timer.cpp',
+	'../../src/host/libpixyusb_swig/helper_commands.cpp'])
 
 setup (name = 'pixy',
 	version = '0.3',


### PR DESCRIPTION
Add python script to capture camera frame via USB.

The original PixyMon tool limits the image resolution to 320x200 because of RAM limitations. Also the 320x200 image is demosaiced to generate an RGB image. This behavior is not necessarily wanted for an IR application.

This tool captures a raw 640x400 image by stitching 320x200 images together. Motion of the camera will show the limitations of the stitching but the scope of the tool is to analyze image quality of changes to pixy lens and/or IR light source.