### PR TITLE
AVX-250: Fix i2c timeout issue

### DIFF
--- a/src/device/main_m4/inc/serial.h
+++ b/src/device/main_m4/inc/serial.h
@@ -38,6 +38,7 @@ int ser_init(SerialCallback callback, SerialCmdCallback cmdCallback);
 void ser_flush();
 int ser_setInterface(uint8_t interface);
 uint8_t ser_getInterface();
+void ser_update();
 void ser_processInput();
 
 #endif

--- a/src/device/main_m4/src/progblobs.cpp
+++ b/src/device/main_m4/src/progblobs.cpp
@@ -133,6 +133,7 @@ static int blobsLoop()
     }
 
     // can do work here while waiting for more data in queue
+    ser_update();
     while(!qqueue_.queued())
     {
         ser_processInput();

--- a/src/device/main_m4/src/serial.cpp
+++ b/src/device/main_m4/src/serial.cpp
@@ -109,10 +109,14 @@ Iserial *ser_getSerial()
     return g_serial;
 }
 
+void ser_update()
+{
+    g_serial->update();
+}
+
 void ser_processInput()
 {
     uint8_t byte;
-    g_serial->update();
 
     switch (g_state)
     {


### PR DESCRIPTION
Bug: The i2c update function was being called too frequent and causing an inactivity counter to trigger.

Fix: Moved serial update function outside of while loop.